### PR TITLE
refactor subprocess to be docker-compose oriented

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,1 +1,1 @@
-includes: ['layer:docker', 'layer:flannel', 'interface:etcd']
+includes: ['layer:docker', 'layer:tls', 'interface:etcd']

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -1,0 +1,13 @@
+agent:
+  image: swarm
+  restart: always
+  command: join --advertise={{addr}}:{{port}} {{connection_string}}/swarm
+{%- if leader %}
+manager:
+  image: swarm
+  restart: always
+  ports:
+    - 2376:2375
+  command: manage {{connection_string}}/swarm
+{% endif -%}
+


### PR DESCRIPTION
refactor the one-off subprocess calls with a docker-compose based launch.
This templatizes both the agent (all machines), and the manager(on the
leader) and runs on port 2376, this is prelimiary as the TLS terminated
docker socket is _supposed_ to reside on this port, but we'll be placing
swarm there instead.
